### PR TITLE
Fix workspace script return code

### DIFF
--- a/shelf.sh
+++ b/shelf.sh
@@ -289,7 +289,7 @@ function workspace() {
             if [ -z "$LABEL" ]; then
                 >&2 echo "Leaving $PWD"
                 cd $(ls -td ~/workspaces/*|head -n1)
-                return 1
+                return 0
             fi
             local WORKSPACES=$(ls -td $WORKSPACE_ROOT/*|awk -F/ '{print $NF}')
             if [ "$ORDER" = "date" ]; then

--- a/shelf/workspace.sh
+++ b/shelf/workspace.sh
@@ -60,7 +60,7 @@ function workspace() {
             if [ -z "$LABEL" ]; then
                 >&2 echo "Leaving $PWD"
                 cd $(ls -td ~/workspaces/*|head -n1)
-                return 1
+                return 0
             fi
             local WORKSPACES=$(ls -td $WORKSPACE_ROOT/*|awk -F/ '{print $NF}')
             if [ "$ORDER" = "date" ]; then


### PR DESCRIPTION
## Summary
- fix workspace script exit status when no label is provided
- regenerate the combined `shelf.sh`

## Testing
- `shellcheck shelf/workspace.sh`

------
https://chatgpt.com/codex/tasks/task_e_68851973f0088328a2cb1dafd530d955